### PR TITLE
Update templates for AWS Lambda to .NET Core 3.1

### DIFF
--- a/content/EventLambdaFunction/EventLambdaFunction.csproj
+++ b/content/EventLambdaFunction/EventLambdaFunction.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.0" />
+    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.1" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />

--- a/content/EventLambdaFunction/Function.cs
+++ b/content/EventLambdaFunction/Function.cs
@@ -16,7 +16,8 @@ namespace EMG
         {
             builder.SetBasePath(Directory.GetCurrentDirectory());
             builder.AddJsonFile("appsettings.json", true, false);
-            builder.AddObject(new {
+            builder.AddObject(new 
+            {
                 //#if (AddLoggly)
                 Loggly = new {
                     ApplicationName = "EMG EventLambdaFunction",

--- a/content/EventLambdaFunction/aws-lambda-tools-defaults.json
+++ b/content/EventLambdaFunction/aws-lambda-tools-defaults.json
@@ -8,10 +8,10 @@
   "profile": "",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "netcoreapp2.1",
+  "framework": "netcoreapp3.1",
   "function-name": "EventLambdaFunction",
   "function-role": "",
-  "function-runtime": "dotnetcore2.1",
+  "function-runtime": "dotnetcore3.1",
   "function-memory-size": 128,
   "function-timeout": 30,
   "function-handler": "EMG.EventLambdaFunction::EMG.Function::FunctionHandlerAsync"

--- a/content/RequestResponseLambdaFunction/Function.cs
+++ b/content/RequestResponseLambdaFunction/Function.cs
@@ -16,7 +16,8 @@ namespace EMG
         {
             builder.SetBasePath(Directory.GetCurrentDirectory());
             builder.AddJsonFile("appsettings.json", true, false);
-            builder.AddObject(new {
+            builder.AddObject(new 
+            {
                 //#if (AddLoggly)
                 Loggly = new {
                     ApplicationName = "EMG RequestResponseLambdaFunction",

--- a/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
+++ b/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.0" />
+    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.1" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />

--- a/content/RequestResponseLambdaFunction/aws-lambda-tools-defaults.json
+++ b/content/RequestResponseLambdaFunction/aws-lambda-tools-defaults.json
@@ -8,10 +8,10 @@
   "profile": "",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "netcoreapp2.1",
+  "framework": "netcoreapp3.1",
   "function-name": "RequestResponseLambdaFunction",
   "function-role": "",
-  "function-runtime": "dotnetcore2.1",
+  "function-runtime": "dotnetcore3.1",
   "function-memory-size": 128,
   "function-timeout": 30,
   "function-handler": "EMG.RequestResponseLambdaFunction::EMG.Function::FunctionHandlerAsync"


### PR DESCRIPTION
- Update to use Kralizek.Lambda.Template 4.0.0
- Change serialization from Newtonsoft.Json to System.Text.Json