### PR TITLE
Refresh templates

### DIFF
--- a/content/BatchJobProcessor/BatchJobProcessor.csproj
+++ b/content/BatchJobProcessor/BatchJobProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EMG</RootNamespace>
     <AssemblyName>EMG.BatchJobProcessor</AssemblyName>
@@ -10,24 +10,24 @@
 
   <ItemGroup>
 <!--#if (ConfigureAWS)-->
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
 <!--#endif-->
 
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.0" />
     
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="AWS.Logger.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="AWS.Logger.AspNetCore" Version="2.2.0" />
     
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/BatchJobProcessor/BatchJobProcessor.csproj
+++ b/content/BatchJobProcessor/BatchJobProcessor.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.0" />
+    <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="AWS.Logger.AspNetCore" Version="2.2.0" />

--- a/content/BatchJobProcessor/Program.cs
+++ b/content/BatchJobProcessor/Program.cs
@@ -65,7 +65,15 @@ namespace EMG
 
             var builder = new ConfigurationBuilder();
             builder.SetBasePath(AppDomain.CurrentDomain.BaseDirectory);
-            builder.AddInMemoryCollection(settings);
+            builder.AddObject(new 
+            {
+                //#if (AddLoggly)
+                Loggly = new {
+                    ApplicationName = "EMG EventLambdaFunction",
+                    ApiKey = "test"
+                }
+                //#endif
+            });
             builder.AddJsonFile("appsettings.json", true, false);
             builder.AddEnvironmentVariables();
 

--- a/content/EventLambdaFunction/EventLambdaFunction.csproj
+++ b/content/EventLambdaFunction/EventLambdaFunction.csproj
@@ -15,14 +15,14 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.1" />
+    <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/HostedService/HostedService.csproj
+++ b/content/HostedService/HostedService.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Nybus)' == 'Current'">
-    <PackageReference Include="Nybus" Version="1.5.2" />
-    <PackageReference Include="Nybus.Extensions.Hosting.HostedService" Version="1.5.2" />
-    <PackageReference Include="Nybus.Engine.RabbitMq" Version="1.5.2" />
+    <PackageReference Include="Nybus" Version="1.5.3" />
+    <PackageReference Include="Nybus.Extensions.Hosting.HostedService" Version="1.5.3" />
+    <PackageReference Include="Nybus.Engine.RabbitMq" Version="1.5.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(Nybus)' == 'Legacy'">
     <PackageReference Include="Nybus.Core" Version="0.6.0.97" />
@@ -28,11 +28,11 @@
     <PackageReference Include="Nybus.Legacy.NetExtensions.Adapters.MassTransit" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(WCF)' == 'True'">
-    <PackageReference Include="EMG.Utilities.ServiceModel" Version="1.4.0" />
+    <PackageReference Include="EMG.Utilities.ServiceModel" Version="1.9.0" />
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(AWS)' == 'True'">
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
+++ b/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
@@ -15,10 +15,10 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Kralizek.Lambda.Template" Version="4.0.1" />
+    <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />

--- a/content/UnitTestProject/CustomAutoDataAttribute.cs
+++ b/content/UnitTestProject/CustomAutoDataAttribute.cs
@@ -6,9 +6,17 @@ namespace Tests
 {
     public class CustomAutoDataAttribute : AutoDataAttribute
     {
-        public CustomAutoDataAttribute() : base (CreateFixture) {}
+        public CustomAutoDataAttribute() : base (FixtureHelper.CreateFixture) { }
+    }
 
-        private static IFixture CreateFixture()
+    public class InlineCustomAutoDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineCustomAutoDataAttribute(params object[] arguments) : base(FixtureHelper.CreateFixture, arguments) { }
+    }
+
+    public static class FixtureHelper
+    {
+        public static IFixture CreateFixture()
         {
             var fixture = new Fixture();
 

--- a/content/UnitTestProject/UnitTestProject.csproj
+++ b/content/UnitTestProject/UnitTestProject.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
 <!--#if (TargetFramework == 'netcore') -->
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 <!-- #elseif (TargetFramework == 'fx')
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
 #elseif (TargetFramework == 'both')
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
 #endif -->
     <IsPackable>false</IsPackable>
     <RootNamespace>Tests</RootNamespace>
@@ -19,10 +19,10 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.11.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.11.0" />
-    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR refreshes all the templates to use

Latest version of EMG and non-EMG packages
Upgrade runtime from .NET Core 2.2 to .NET Core 3.1

WebApiHost template will be handled in #20