### PR TITLE
re #18096 - Updates to EMG.Extensions.Logging.Loggly to avoid Mapping…

### DIFF
--- a/content/BatchJobProcessor/BatchJobProcessor.csproj
+++ b/content/BatchJobProcessor/BatchJobProcessor.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
 <!--#endif-->
 
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />

--- a/content/EventLambdaFunction/EventLambdaFunction.csproj
+++ b/content/EventLambdaFunction/EventLambdaFunction.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />

--- a/content/HostedService/HostedService.csproj
+++ b/content/HostedService/HostedService.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />

--- a/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
+++ b/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
 <!--#if (AddLoggly)-->
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.0" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
 <!--#endif-->
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />

--- a/content/WebApiHost/WebApiHost.csproj
+++ b/content/WebApiHost/WebApiHost.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="EMG.Extensions.AspNetCore.Authentication.JWT" Version="1.1.0" />
     <PackageReference Include="EMG.Extensions.AspNetCore.Filters.Error" Version="1.1.0" />
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />

--- a/content/WindowsService/WindowsService.csproj
+++ b/content/WindowsService/WindowsService.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="EMG.Utilities.Hosting.TopShelf" Version="1.3.0" />
 
-    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.0.2" />
+    <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
 
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />


### PR DESCRIPTION
…Conflict with Nybus v0

- updating EMG.Extensions.Logging package, cause the old one causes some overlap in Loggly and give us incorrect logs