### PR TITLE
re #20796 - Update old dotnet core versions to .NET 6 - templates repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The current version of the package contains the following templates.
 |ASP.NET Core API                          |emg-web-api               
 |Batch JobProcessor                        |emg-batch-jobprocessor    
 |Hosted Service                            |emg-hosted-service        
-|Lambda Local Runner                       |emg-lambda-local-runner   
 |Lambda Event Function                     |emg-lambda-event          
 |Lambda RequestResponse Function           |emg-lambda-requestresponse
 |Test Project                              |emg-test-lib              
@@ -60,14 +59,6 @@ The application can be customized with the following parameters:
 * `--add-wcf` adds support for hosting WCF services. Requires .NET Framework 4.8
 * `--add-aws` adds basic setup to AWS services
 * `--force-net48` forces the runtime to be .NET Framework 4.8 even if the application could run on .NET Core 3.1
-
-### Lambda Local Runner
-
-```
-dotnet new emg-lambda-local-runner
-```
-
-This template creates a console application using the `LambdaRunner` to host locally a AWS Lambda function.
 
 ### Lambda Event Function
 
@@ -146,7 +137,6 @@ Example:
       [EMG] Batch JobProcessor (emg-batch-jobprocessor) C#
       [EMG] Lambda Event Function (emg-lambda-event) C#
       [EMG] Hosted Service (emg-hosted-service) C#
-      [EMG] Lambda Local Runner (emg-lambda-local-runner) C#
       [EMG] Lambda RequestResponse Function (emg-lambda-requestresponse) C#
       [EMG] Test Project (emg-test-lib) C#
       [EMG] ASP.NET Core API (emg-web-api) C#

--- a/Templates.sln
+++ b/Templates.sln
@@ -1,25 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{C506315D-0E8E-4CA0-8804-11562D25ECFD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BatchJobProcessor", "content\BatchJobProcessor\BatchJobProcessor.csproj", "{9CE9AE3F-E1BD-41FA-B50D-DF2F63B49C8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BatchJobProcessor", "content\BatchJobProcessor\BatchJobProcessor.csproj", "{9CE9AE3F-E1BD-41FA-B50D-DF2F63B49C8A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLambdaFunction", "content\EventLambdaFunction\EventLambdaFunction.csproj", "{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventLambdaFunction", "content\EventLambdaFunction\EventLambdaFunction.csproj", "{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LambdaLocalRunner", "content\LambdaLocalRunner\LambdaLocalRunner.csproj", "{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RequestResponseLambdaFunction", "content\RequestResponseLambdaFunction\RequestResponseLambdaFunction.csproj", "{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RequestResponseLambdaFunction", "content\RequestResponseLambdaFunction\RequestResponseLambdaFunction.csproj", "{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTestProject", "content\UnitTestProject\UnitTestProject.csproj", "{95A316AC-A45D-41A9-8A8E-4E38EC446779}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTestProject", "content\UnitTestProject\UnitTestProject.csproj", "{95A316AC-A45D-41A9-8A8E-4E38EC446779}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiHost", "content\WebApiHost\WebApiHost.csproj", "{0EB74EF5-B631-468B-A504-93FC8E1AB549}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiHost", "content\WebApiHost\WebApiHost.csproj", "{0EB74EF5-B631-468B-A504-93FC8E1AB549}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsService", "content\WindowsService\WindowsService.csproj", "{B97D0670-B66D-4EE0-B9AA-C87763E0DB75}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsService", "content\WindowsService\WindowsService.csproj", "{B97D0670-B66D-4EE0-B9AA-C87763E0DB75}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HostedService", "content\HostedService\HostedService.csproj", "{DDD24FF1-28BB-487F-A04C-67BAE179CC04}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HostedService", "content\HostedService\HostedService.csproj", "{DDD24FF1-28BB-487F-A04C-67BAE179CC04}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,9 +27,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9CE9AE3F-E1BD-41FA-B50D-DF2F63B49C8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -58,18 +53,6 @@ Global
 		{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1}.Release|x64.Build.0 = Release|Any CPU
 		{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1}.Release|x86.ActiveCfg = Release|Any CPU
 		{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1}.Release|x86.Build.0 = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|x64.Build.0 = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Debug|x86.Build.0 = Debug|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|x64.ActiveCfg = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|x64.Build.0 = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|x86.ActiveCfg = Release|Any CPU
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC}.Release|x86.Build.0 = Release|Any CPU
 		{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -131,14 +114,19 @@ Global
 		{DDD24FF1-28BB-487F-A04C-67BAE179CC04}.Release|x86.ActiveCfg = Release|Any CPU
 		{DDD24FF1-28BB-487F-A04C-67BAE179CC04}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9CE9AE3F-E1BD-41FA-B50D-DF2F63B49C8A} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{5F17DEFA-85D0-495B-87E8-C6AC9A6751E1} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
-		{64B732A0-87A4-4E98-9EF2-492F4C1B59FC} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{FA197B7F-8ED6-43D8-832F-E9A5CD667B5E} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{95A316AC-A45D-41A9-8A8E-4E38EC446779} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{0EB74EF5-B631-468B-A504-93FC8E1AB549} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{B97D0670-B66D-4EE0-B9AA-C87763E0DB75} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
 		{DDD24FF1-28BB-487F-A04C-67BAE179CC04} = {C506315D-0E8E-4CA0-8804-11562D25ECFD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1E5EE368-CCA6-4EC5-88DC-35C383629910}
 	EndGlobalSection
 EndGlobal

--- a/content/BatchJobProcessor/BatchJobProcessor.csproj
+++ b/content/BatchJobProcessor/BatchJobProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EMG</RootNamespace>
     <AssemblyName>EMG.BatchJobProcessor</AssemblyName>
@@ -16,13 +16,13 @@
     <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
 <!--#endif-->
 
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
     
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />

--- a/content/EventLambdaFunction/EventLambdaFunction.csproj
+++ b/content/EventLambdaFunction/EventLambdaFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -20,9 +20,9 @@
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/EventLambdaFunction/Properties/launchSettings.json
+++ b/content/EventLambdaFunction/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Mock Lambda Test Tool": {
+      "commandName": "Executable",
+      "commandLineArgs": "--port 5050",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+    }
+  }
+}

--- a/content/EventLambdaFunction/aws-lambda-tools-defaults.json
+++ b/content/EventLambdaFunction/aws-lambda-tools-defaults.json
@@ -8,10 +8,10 @@
   "profile": "",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net6.0",
   "function-name": "EventLambdaFunction",
   "function-role": "",
-  "function-runtime": "dotnetcore3.1",
+  "function-runtime": "dotnet6",
   "function-memory-size": 128,
   "function-timeout": 30,
   "function-handler": "EMG.EventLambdaFunction::EMG.Function::FunctionHandlerAsync"

--- a/content/HostedService/HostedService.csproj
+++ b/content/HostedService/HostedService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework Condition="'$(RequiresWindows)' == 'False' OR '$(RequiresWindows)' == ''">netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="'$(RequiresWindows)' == 'False' OR '$(RequiresWindows)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(RequiresWindows)' == 'True'">net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EMG.Hosted_Service</RootNamespace>
@@ -14,7 +14,7 @@
     <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Nybus)' == 'Current'">

--- a/content/RequestResponseLambdaFunction/Properties/launchSettings.json
+++ b/content/RequestResponseLambdaFunction/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Mock Lambda Test Tool": {
+      "commandName": "Executable",
+      "commandLineArgs": "--port 5050",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+    }
+  }
+}

--- a/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
+++ b/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="3.1.0" />
 <!--#if (ConfigureAWS)-->
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
 <!--#endif-->
@@ -20,9 +20,9 @@
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="4.1.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.Objects" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/RequestResponseLambdaFunction/aws-lambda-tools-defaults.json
+++ b/content/RequestResponseLambdaFunction/aws-lambda-tools-defaults.json
@@ -8,10 +8,10 @@
   "profile": "",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net6.0",
   "function-name": "RequestResponseLambdaFunction",
   "function-role": "",
-  "function-runtime": "dotnetcore3.1",
+  "function-runtime": "dotnet6",
   "function-memory-size": 128,
   "function-timeout": 30,
   "function-handler": "EMG.RequestResponseLambdaFunction::EMG.Function::FunctionHandlerAsync"

--- a/content/UnitTestProject/UnitTestProject.csproj
+++ b/content/UnitTestProject/UnitTestProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 <!--#if (TargetFramework == 'netcore') -->
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 <!-- #elseif (TargetFramework == 'fx')
     <TargetFramework>net48</TargetFramework>
 #elseif (TargetFramework == 'both')

--- a/content/WebApiHost/Program.cs
+++ b/content/WebApiHost/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace WebApiHost

--- a/content/WebApiHost/Startup.cs
+++ b/content/WebApiHost/Startup.cs
@@ -9,10 +9,10 @@ using EMG.Wcf.Discovery.Service;
 //#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 //#if (AddNybus)
 using Nybus;
 //#endif
@@ -21,7 +21,7 @@ namespace WebApiHost
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
+        public Startup(IConfiguration configuration, IHostEnvironment hostingEnvironment)
         {
             Configuration = configuration;
             HostingEnvironment = hostingEnvironment;
@@ -29,11 +29,11 @@ namespace WebApiHost
 
         public IConfiguration Configuration { get; }
 
-        public IHostingEnvironment HostingEnvironment { get; }
+        public IHostEnvironment HostingEnvironment { get; }
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc(ConfigureMvc).SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddMvc(ConfigureMvc);
 
             // Adds support for ASP.NET Core health checks: https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2
             services.AddHealthChecks(); 
@@ -89,11 +89,12 @@ namespace WebApiHost
             {
                 // Adds support for friendly error when an MVC action throws an uncaught exception
                 options.AddExceptionHandlerFilter();
+                options.EnableEndpointRouting = false;
             }
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/content/WebApiHost/WebApiHost.csproj
+++ b/content/WebApiHost/WebApiHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/content/WindowsService/WindowsService.csproj
+++ b/content/WindowsService/WindowsService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EMG.WindowsService</RootNamespace>
     <AssemblyName>EMG.Service.WindowsService</AssemblyName>
@@ -14,8 +14,8 @@
     <PackageReference Include="EMG.Extensions.Logging.Loggly" Version="1.1.1" />
     <PackageReference Include="Kralizek.Extensions.Logging" Version="2.0.1" />
 
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Nybus)' == 'Current'">


### PR DESCRIPTION
Update to .NET 6 and remove LambdaLocalRunner since we now have Mock Lambda Test tool