### PR TITLE
Runtime specification

### DIFF
--- a/content/BatchJobProcessor/BatchJobProcessor.csproj
+++ b/content/BatchJobProcessor/BatchJobProcessor.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EMG</RootNamespace>
     <AssemblyName>EMG.BatchJobProcessor</AssemblyName>

--- a/content/EventLambdaFunction/EventLambdaFunction.csproj
+++ b/content/EventLambdaFunction/EventLambdaFunction.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
+++ b/content/RequestResponseLambdaFunction/RequestResponseLambdaFunction.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 


### PR DESCRIPTION
Added specific linux runtime to both lambdas and the batch job templates
That is to show the intent that it is to be run under linux, and gives compile time errors if code is not compatible with it